### PR TITLE
Implement face descriptor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This script can be used to fix the metadata of those fonts files.
 
 ## Usage
 
-```
+```sh
 fixfont.py <font.woff2> [-f "family name"] [-s "subfamily name"] [-o output.woff2]
 ```
 
@@ -17,6 +17,16 @@ fixfont.py <font.woff2> [-f "family name"] [-s "subfamily name"] [-o output.woff
 - `-f family name`: the name of the font, make sure to use quotes if this contains spaces, e.g `-f "My Font"`. If not provided, it will try to figure out the name from the input file.
 - `-s subfamily name`: also called the style or variant of the font, usually this is something like `-s Regular`, `-s Bold`, `-s Thin`, etc. If not provided, it will try to figure out the name from the input file.
 - `-o output.woff2`: the path to where to write the result, if not specified, the script will put it next to the input file and will output where it has written the result.
+
+### Additional Options
+
+In addition to updating the name, it is also possible to set some other font metadata by using the following options:
+
+- `--weight-class=400`: sets the weight of the font to the given numeric value. Here 400 is used, meaning "normal". See also the [list of common values](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight).
+- `--width-class=5`: sets the width class of the font to the given integer class, which should be between 1 and 9. Here 5 is used, meaning "normal". See also the [list of valid values](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
+- `--italic`: marks the font as italic.
+- `--no-italic`: marks the font as not italic.
+- `--strip-extended-metadata`: removes all extended metadata from the font, if present. This metadata is not required and may be removed to reduce filesize.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This script can be used to fix the metadata of those fonts files.
 
 ## Usage
 
-```sh
+To fix a font's display names (the most common use case), run:
+
+```
 fixfont.py <font.woff2> [-f "family name"] [-s "subfamily name"] [-o output.woff2]
 ```
 
@@ -22,6 +24,7 @@ fixfont.py <font.woff2> [-f "family name"] [-s "subfamily name"] [-o output.woff
 
 In addition to updating the name, it is also possible to set some other font metadata by using the following options:
 
+- `--no-rename`: by default, the font family and subfamily will always be renamed (automatically based on the filename, if no name options are provided). Pass this flag to disable renaming.
 - `--weight-class=400`: sets the weight of the font to the given numeric value. Here 400 is used, meaning "normal". See also the [list of common values](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight).
 - `--width-class=5`: sets the width class of the font to the given integer class, which should be between 1 and 9. Here 5 is used, meaning "normal". See also the [list of valid values](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
 - `--italic`: marks the font as italic.

--- a/fixfont.py
+++ b/fixfont.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument("input")
     parser.add_argument("-f", "--family-name")
     parser.add_argument("-s", "--subfamily-name")
+    parser.add_argument("--no-rename", action="store_true")
     parser.add_argument("--weight-class", type=int)
     parser.add_argument("--width-class", type=int)
     parser.add_argument("-i", "--italic", action=argparse.BooleanOptionalAction)
@@ -35,7 +36,7 @@ def main():
         print("Input file is not a WOFF2 font", file=sys.stderr)
         return 1
 
-    if options.family_name or options.subfamily_name:
+    if not options.no_rename:
         family, subfamily = extract_names(options.input, options.family_name, options.subfamily_name)
         full = "%s %s" % (family, subfamily)
         postscript = "%s-%s" % (postscriptify(family), postscriptify(subfamily))[:63]

--- a/fixfont.py
+++ b/fixfont.py
@@ -17,11 +17,15 @@ PREFERRED_SUBFAMILY = 17
 WWS_FAMILY = 21
 WWS_SUBFAMILY = 22
 
-def main(args=None):
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input")
     parser.add_argument("-f", "--family-name")
     parser.add_argument("-s", "--subfamily-name")
+    parser.add_argument("--weight-class", type=int)
+    parser.add_argument("--width-class", type=int)
+    parser.add_argument("-i", "--italic", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--strip-extended-metadata")
     parser.add_argument("-o", "--output")
     options = parser.parse_args()
 
@@ -31,23 +35,32 @@ def main(args=None):
         print("Input file is not a WOFF2 font", file=sys.stderr)
         return 1
 
-    family, subfamily = extract_names(options.input, options.family_name, options.subfamily_name)
-    full = "%s %s" % (family, subfamily)
-    postscript = "%s-%s" % (postscriptify(family), postscriptify(subfamily))[:63]
+    if options.family_name or options.subfamily_name:
+        family, subfamily = extract_names(options.input, options.family_name, options.subfamily_name)
+        full = "%s %s" % (family, subfamily)
+        postscript = "%s-%s" % (postscriptify(family), postscriptify(subfamily))[:63]
 
-    for rec in font["name"].names:
-        if rec.nameID in [FAMILY, PREFERRED_FAMILY, WWS_FAMILY]:
-            rec.string = family
-        elif rec.nameID in [SUBFAMILY, PREFERRED_SUBFAMILY, WWS_SUBFAMILY]:
-            rec.string = subfamily
-        elif rec.nameID == FULL_NAME:
-            rec.string = full
-        elif rec.nameID == POSTSCRIPT_NAME:
-            rec.string = postscript
+        for rec in font["name"].names:
+            if rec.nameID in [FAMILY, PREFERRED_FAMILY, WWS_FAMILY]:
+                rec.string = family
+            elif rec.nameID in [SUBFAMILY, PREFERRED_SUBFAMILY, WWS_SUBFAMILY]:
+                rec.string = subfamily
+            elif rec.nameID == FULL_NAME:
+                rec.string = full
+            elif rec.nameID == POSTSCRIPT_NAME:
+                rec.string = postscript
+
+    if options.weight_class:
+        set_weight_class(font, options.weight_class)
+    if options.width_class:
+        set_width_class(font, options.width_class)
+    if options.italic is not None:
+        set_italic(font, options.italic)
 
     # Remove extended metadata and private data
-    font.flavorData.metaData = None
-    font.flavorData.privData = None
+    if options.strip_extended_metadata:
+        font.flavorData.metaData = None
+        font.flavorData.privData = None
 
     if options.output:
         font.save(options.output)
@@ -56,6 +69,22 @@ def main(args=None):
         outfile = makeOutputFileName(filename, None, ext)
         font.save(outfile)
         print("Output saved in “%s”" % outfile)
+
+def set_weight_class(font, weight_class: int):
+    font["OS/2"].usWeightClass = weight_class
+
+def set_width_class(font, width_class: int):
+    font["OS/2"].usWidthClass = width_class
+
+def set_italic(font, italic: bool):
+    os2_italic_flag_bitmask = 0x1
+    mac_style_italic_flag_bitmask = 0x2
+    if italic:
+        font["OS/2"].fsSelection |= os2_italic_flag_bitmask
+        font["head"].macStyle |= mac_style_italic_flag_bitmask
+    else:
+        font["OS/2"].fsSelection &= ~os2_italic_flag_bitmask
+        font["head"].macStyle &= ~mac_style_italic_flag_bitmask
 
 def postscriptify(name):
     return "".join(char for char in unidecode(name) if 33 <= ord(char) <= 126 and char not in " [](){}<>/%")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Brotli==1.1.0
-fonttools==4.51.0
+fonttools==4.59.1
+lxml==6.0.1
 unicodedata2==15.1.0
 Unidecode==1.3.8
 zopfli==0.2.3


### PR DESCRIPTION
This PR adds a series of optional arguments that can be used to change metadata describing the font face.

- `--weight-class`
- `--width-class`
- `--[no-]italic`

See the README changes for more information.

This PR also bumps dependency versions to the latest.